### PR TITLE
fonts are also affecting button - textarea - input now

### DIFF
--- a/admin_persian/static/admin_persian/css/parastoo.css
+++ b/admin_persian/static/admin_persian/css/parastoo.css
@@ -1,4 +1,3 @@
-
 @font-face {
     font-family: parastoo;
     src: url("../fonts/parastoo/Parastoo.eot") format('eot');
@@ -9,6 +8,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: parastoo;
 }

--- a/admin_persian/static/admin_persian/css/sahel.css
+++ b/admin_persian/static/admin_persian/css/sahel.css
@@ -1,4 +1,3 @@
-
 @font-face {
     font-family: sahel;
     src: url("../fonts/sahel/Sahel.eot") format('eot');
@@ -8,6 +7,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: sahel;
 }

--- a/admin_persian/static/admin_persian/css/samim.css
+++ b/admin_persian/static/admin_persian/css/samim.css
@@ -8,6 +8,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: samim;
 }

--- a/admin_persian/static/admin_persian/css/shabnam.css
+++ b/admin_persian/static/admin_persian/css/shabnam.css
@@ -8,6 +8,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: shabnam;
 }

--- a/admin_persian/static/admin_persian/css/tanha.css
+++ b/admin_persian/static/admin_persian/css/tanha.css
@@ -1,4 +1,3 @@
-
 @font-face {
     font-family: tanha;
     src: url("../fonts/tanha/Tanha.eot") format('eot');
@@ -9,6 +8,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: tanha;
 }

--- a/admin_persian/static/admin_persian/css/vazir.css
+++ b/admin_persian/static/admin_persian/css/vazir.css
@@ -1,4 +1,3 @@
-
 @font-face {
     font-family: vazir;
     src: url("../fonts/vazir/Vazir.eot") format('eot');
@@ -9,6 +8,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: vazir;
 }

--- a/admin_persian/static/admin_persian/css/yekan.css
+++ b/admin_persian/static/admin_persian/css/yekan.css
@@ -7,6 +7,9 @@
     font-style: normal;
 }
 
-* {
+body,
+button,
+input,
+textarea {
     font-family: yekan;
 }


### PR DESCRIPTION
In CSS * won't affect on all tags I added some tag like `button`, `input`, `textarea` to CSS in this package and now fonts are affective on all elements in Django admin